### PR TITLE
refactor: Exclude node_modules from path

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -26,14 +26,11 @@ jobs:
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-
 
       - name: Install dependencies
-        if: |
-          steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: format

--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -28,14 +28,11 @@ jobs:
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-
 
       - name: Install dependencies
-        if: |
-          steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: Tweet


### PR DESCRIPTION
## Description

`Yarn2`에서는 `node_modules`를 캐싱하지 않는 것이 성능 측면에서 더 나으므로 캐싱 대상에서 제외함.

## Related Issues

[yarnpkg/berry #2621](https://github.com/yarnpkg/berry/discussions/2621#discussioncomment-505872)