### PR TITLE
chore: Update moment-timezone version to v0.5.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "axios": "^1.1.3",
     "cheerio": "^1.0.0-rc.12",
-    "moment-timezone": "^0.5.38",
+    "moment-timezone": "^0.5.39",
     "twit": "^2.2.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,7 +166,7 @@ __metadata:
   dependencies:
     axios: ^1.1.3
     cheerio: ^1.0.0-rc.12
-    moment-timezone: ^0.5.38
+    moment-timezone: ^0.5.39
     prettier: ^2.7.1
     twit: ^2.2.11
   languageName: unknown
@@ -445,12 +445,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment-timezone@npm:^0.5.38":
-  version: 0.5.38
-  resolution: "moment-timezone@npm:0.5.38"
+"moment-timezone@npm:^0.5.39":
+  version: 0.5.39
+  resolution: "moment-timezone@npm:0.5.39"
   dependencies:
     moment: ">= 2.9.0"
-  checksum: ff7077de41f2c41a0026cd2b310154c14df8f918331a4ebe88f5872a599deb5e463b123c96990dc447b7474a81c9f3aef7ac57c3d0dfc3bfb9af2cc5b0bca826
+  checksum: 9f972d3a29b2726d4fd1464df27738b756441fe57575f087cda91b7716a5a31d2cfd274255e3edfb15eb60af3ccf33fd339527b456092cac1a2a4124e4369c8b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

[moment-timezone@v0.5.39](https://github.com/moment/moment-timezone/releases/tag/0.5.39) release에 따라 패키지를 업데이트함.
